### PR TITLE
Scheduled CI and conditional failure for code coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master, develop ]
   pull_request:
     branches: [ master, develop ] 
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:
@@ -17,22 +19,26 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
+
     - name: Install poetry
       run: |
         python -m pip install --upgrade pip
         pip install poetry
+
     - name: Install multibind with poetry
       run: |
         poetry install
+
     - name: Test with pytest
       run: |
         cd tests/
         poetry run pytest -v --cov=multibind --cov-report=xml
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:
         directory: .
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.event_name == 'pull_request' }}
         files: coverage.xml
         name: codecov-umbrella
         verbose: true


### PR DESCRIPTION
We should be testing the code regularly, even without new additions.
Additionally, since codecov tends to not like this behavior, we will ignore codecov failures unless it's on a pull request.