### PR TITLE
Add conversion of state label columns to str if necessary

### DIFF
--- a/multibind/nonequilibrium.py
+++ b/multibind/nonequilibrium.py
@@ -28,13 +28,8 @@ def rate_matrix(filename: str) -> (Multibind, np.ndarray, np.ndarray):
         2D array with the standard error on the projected rates.
     """
 
-    _rates = pd.read_csv(filename, header=0)
-
-    # convert state label columns to str (stored as plain objects in pandas apparently... ) if necessary
-    if not _rates.state1.dtype == object:
-        _rates['state1'] = _rates['state1'].astype(str)
-        _rates['state2'] = _rates['state2'].astype(str)
-
+    _rates = pd.read_csv(filename, header=0, dtype={'state1': str, 'state2': str, 'k': np.float64, 'var': np.float64})
+    
     with tempfile.TemporaryDirectory() as tmpdirname:
         # multibind requires that states and graphs are defined within csv files, we will create temporary files
         states_filename = os.path.join(tmpdirname, "states.csv")

--- a/multibind/nonequilibrium.py
+++ b/multibind/nonequilibrium.py
@@ -30,6 +30,11 @@ def rate_matrix(filename: str) -> (Multibind, np.ndarray, np.ndarray):
 
     _rates = pd.read_csv(filename, header=0)
 
+    # convert state label columns to str (stored as plain objects in pandas apparently... ) if necessary
+    if not _rates.state1.dtype == object:
+        _rates['state1'] = _rates['state1'].astype(str)
+        _rates['state2'] = _rates['state2'].astype(str)
+
     with tempfile.TemporaryDirectory() as tmpdirname:
         # multibind requires that states and graphs are defined within csv files, we will create temporary files
         states_filename = os.path.join(tmpdirname, "states.csv")

--- a/multibind/nonequilibrium.py
+++ b/multibind/nonequilibrium.py
@@ -29,7 +29,6 @@ def rate_matrix(filename: str) -> (Multibind, np.ndarray, np.ndarray):
     """
 
     _rates = pd.read_csv(filename, header=0, dtype={'state1': str, 'state2': str, 'k': np.float64, 'var': np.float64})
-    
     with tempfile.TemporaryDirectory() as tmpdirname:
         # multibind requires that states and graphs are defined within csv files, we will create temporary files
         states_filename = os.path.join(tmpdirname, "states.csv")


### PR DESCRIPTION
pd.read_csv by default sets columns to int or float if they are purely numeric, which causes the string matching done later to fail and return an empty dataframe (which then throws an error when attempting to access its elements)