### PR TITLE
update to support Python 3.10 to 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master, develop ]
   pull_request:
-    branches: [ master, develop ] 
+    branches: [ master, develop ]
   schedule:
     - cron: '0 0 * * *'
 
@@ -12,18 +12,22 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install poetry
       run: |
         python -m pip install --upgrade pip
-        pip install poetry
+        pip install "poetry>=2,<3"
 
     - name: Install multibind with poetry
       run: |
@@ -35,7 +39,7 @@ jobs:
         poetry run pytest -v --cov=multibind --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         directory: .
         fail_ci_if_error: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,10 +39,11 @@ jobs:
         poetry run pytest -v --cov=multibind --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         directory: .
         fail_ci_if_error: ${{ github.event_name == 'pull_request' }}
         files: coverage.xml
         name: codecov-umbrella
+        token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.xml
 docs/build/
 docs/_build/
 docs/generated/
+.cursor/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,21 +1,16 @@
-# .readthedocs.yml
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
 
-# Required
 version: 2
 
-# Build documentation in with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
-# Optionally set the version of Python and requirements required to build your docs
 python:
   install:
     - method: pip

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2025-04-19    0.2.1
+orbeckst
+
+Support Python 3.10 - 3.14.
+
+
 2022-02-22    0.2.0
 ianmkenney
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,81 @@
+# Installing multibind
+
+## Requirements
+
+- **Python** 3.10, 3.11, 3.12, 3.13, or 3.14 (see `pyproject.toml` for the exact supported range).
+- **Dependencies** (installed automatically with the methods below): NumPy, pandas, SciPy, NetworkX, and xarray. NumPy 1.x is allowed on older Pythons; very new interpreters (for example 3.14) typically need a **NumPy 2.x** build that provides wheels for that version.
+
+## Install with Poetry (recommended for development)
+
+[Poetry](https://python-poetry.org/docs/#installation) manages the environment and resolves versions from `pyproject.toml`.
+
+From the root of a clone of this repository:
+
+```bash
+poetry install
+```
+
+This installs **multibind** in editable mode plus **dev** tools (pytest, Sphinx, IPython, etc.).
+
+To install only runtime dependencies (no dev extras):
+
+```bash
+poetry install --without dev
+```
+
+Run the test suite (paths in the tests assume the working directory is `tests/`):
+
+```bash
+cd tests
+poetry run pytest -v
+```
+
+## Install with pip
+
+### From a local checkout
+
+Create and activate a virtual environment, then from the repository root:
+
+```bash
+python -m pip install --upgrade pip
+pip install .
+```
+
+Editable install while you change the code:
+
+```bash
+pip install -e .
+```
+
+### From GitHub
+
+Replace the URL if you use a fork:
+
+```bash
+pip install "multibind @ git+https://github.com/BecksteinLab/multibind.git"
+```
+
+For a specific branch or tag, use the corresponding revision in the URL (see [pip VCS support](https://pip.pypa.io/en/stable/topics/vcs-support/)).
+
+### From PyPI
+
+If a release is published on PyPI:
+
+```bash
+pip install multibind
+```
+
+## Conda or Mamba environments
+
+Create an environment with a suitable Python version, activate it, then use **pip** inside that environment as above (from a clone or from Git/PyPI). Avoid mixing Poetry and conda installs of the same package in one environment unless you know how they interact.
+
+## Documentation
+
+To build the HTML docs locally, install dev dependencies (e.g. `poetry install`), then:
+
+```bash
+cd docs
+sphinx-build -b html . _build/html
+```
+
+Online documentation: [multibind.readthedocs.io](https://multibind.readthedocs.io/).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ This criterion is only satisfied when all the differences in a closed loop vanis
 Multibind is a Python package that allows for the combination of these differences, along with their variances, into a set of data-informed and thermodynamically consistent state free energies.
 Additionally, multibind supports cycles whose free energies are dependent on multiple ligand concentrations.
 
+## Installation
+
+Requires **Python 3.10** through **3.14**. With [Poetry](https://python-poetry.org/):
+
+```bash
+poetry install
+```
+
+For pip, conda, editable installs, tests, and building docs, see **[INSTALL.md](INSTALL.md)**.
+
 ## State definitions
 
 States are minimally defined by a name and should be added to a csv file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,12 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
-numpy = ">=1.21.4,<3"
-pandas = "^2.2.3"
-scipy = "^1.11"
-networkx = "^3.2"
-xarray = "^2024.1"
+# Dependency floors: see PyPI requires_python / classifiers for 3.10–3.14 (pandas 2.3.3+ for 3.14; scipy ≥1.11.4 for 3.13+).
+numpy = ">=1.22.4,<3"
+pandas = ">=2.3.3,<3"
+scipy = ">=1.11.4,<2"
+networkx = ">=3.2,<4"
+xarray = ">=2024.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,20 +6,18 @@ authors = ["Ian Kenney <ikenney@asu.edu>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8,<3.11"
-numpy = "^1.21.4"
-pandas = "^1.3.4"
-scipy = "^1.7.2"
-networkx = "^2.6.3"
-xarray = "^0.20.2"
+python = ">=3.10,<3.15"
+numpy = ">=1.21.4,<3"
+pandas = "^2.2.3"
+scipy = "^1.11"
+networkx = "^3.2"
+xarray = "^2024.1"
 
-[tool.poetry.dev-dependencies]
-pytest = "^6.2.5"
-ipython = "^7.30.1"
-codecov = "^2.1.12"
-pytest-cov = "^3.0.0"
-Sphinx = "^4.4.0"
-pdbpp = "^0.10.3"
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+ipython = "^8.18"
+pytest-cov = "^5.0"
+Sphinx = "^8.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_4_state.py
+++ b/tests/test_4_state.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 class TestG(object):
 
-    def setup(self):
+    def setup_method(self):
         self.c = mb.Multibind()
         self.statefile = "../examples/input/4-state-diamond/states.csv"
         self.graphfile = "../examples/input/4-state-diamond/graph.csv"

--- a/tests/test_4_state_sodium_proton.py
+++ b/tests/test_4_state_sodium_proton.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 
 class TestG(object):
 
-    def setup(self):
+    def setup_method(self):
         self.c = mb.Multibind()
         self.c.read_graph("../examples/input/4-state-sodium-proton/graph.csv")
         self.c.read_states("../examples/input/4-state-sodium-proton/states.csv")

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -8,7 +8,7 @@ import numpy.testing as npt
 
 class TestG_missing_coordinate(object):
 
-    def setup(self):
+    def setup_method(self):
 
         self.concentrations = OrderedDict(
             [('H+', [1, 2, 3, 4, 5, 6, 7]),
@@ -39,7 +39,7 @@ class TestG_missing_coordinate(object):
 
 class TestG(object):
 
-    def setup(self):
+    def setup_method(self):
 
         self.concentrations = OrderedDict()
 


### PR DESCRIPTION
Support Python 3.10 to 3.14
- update dependencies
- update tests to work with modern pytest
- update actions in workflow
- added INSTALL.md

Used cursor for this PR.