### PR TITLE
updated workflow for deployment

### DIFF
--- a/.github/actions/wait-for-pypi-version/action.yaml
+++ b/.github/actions/wait-for-pypi-version/action.yaml
@@ -1,0 +1,93 @@
+name: 'Wait for PyPI version'
+description: 'Wait for a specific package version to become available on PyPI or TestPyPI'
+inputs:
+  repository:
+    description: 'PyPI repository type: "pypi" or "testpypi"'
+    required: true
+  package:
+    description: 'Package name'
+    required: true
+  version:
+    description: 'Package version to wait for'
+    required: true
+  max_attempts:
+    description: 'Maximum number of retry attempts'
+    required: false
+    default: '30'
+  wait_seconds:
+    description: 'Seconds to wait between attempts'
+    required: false
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - name: Install requests
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+
+    - name: Wait for version to be available
+      shell: python
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        PACKAGE: ${{ inputs.package }}
+        VERSION: ${{ inputs.version }}
+        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        WAIT_SECONDS: ${{ inputs.wait_seconds }}
+      run: |
+        import os
+        import sys
+        import time
+
+        import requests
+
+        repository = os.environ["REPOSITORY"].strip().lower()
+        package = os.environ["PACKAGE"]
+        version = os.environ["VERSION"]
+        max_attempts = int(os.environ.get("MAX_ATTEMPTS", "30"))
+        wait_seconds = int(os.environ.get("WAIT_SECONDS", "10"))
+
+        if repository == "testpypi":
+            api_url = f"https://test.pypi.org/pypi/{package}/json"
+            repo_name = "TestPyPI"
+        elif repository == "pypi":
+            api_url = f"https://pypi.org/pypi/{package}/json"
+            repo_name = "PyPI"
+        else:
+            print(
+                f"ERROR: repository must be 'pypi' or 'testpypi', got {repository!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        for attempt in range(max_attempts):
+            try:
+                r = requests.get(api_url, timeout=10)
+                r.raise_for_status()
+                data = r.json()
+                versions = data.get("releases", {})
+                keys = list(versions.keys())
+                print("Available versions:", keys[-10:])  # Show last 10 versions
+                if version in versions:
+                    print(f"✓ Version {version} is available on {repo_name}")
+                    print(f"Version {version} is now available on {repo_name}")
+                    sys.exit(0)
+                print(f"✗ Version {version} is NOT available on {repo_name}")
+            except Exception as e:
+                print(f"Error checking version: {e}")
+
+            current = attempt + 1
+            print(
+                f"Attempt {current}/{max_attempts}: Version {version} not yet available "
+                f"on {repo_name}, waiting {wait_seconds} seconds..."
+            )
+            time.sleep(wait_seconds)
+
+        print(
+            f"ERROR: Version {version} did not become available on {repo_name} "
+            f"after {max_attempts} attempts",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,233 @@
+name: Build and upload to PyPI
+
+on:
+  push:
+    tags:
+      - "*"
+  release:
+    types:
+      - published
+
+concurrency:
+  group: "${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package (wheel and sdist)
+        run: python -m build
+
+      - name: Check package
+        run: twine check dist/*
+
+      - name: Extract package version
+        id: extract-version
+        run: |
+          WHEEL_FILE=$(ls dist/*.whl)
+          VERSION=$(basename "$WHEEL_FILE" | sed -n 's/multibind-\([^-]*\)-.*/\1/p')
+          if [ -z "$VERSION" ]; then
+            python -m pip install --upgrade pip
+            pip install "$WHEEL_FILE" --quiet
+            VERSION=$(python -c "import multibind; print(multibind.__version__)")
+            pip uninstall -y multibind --quiet
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION"
+
+      - name: Upload dist files
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-files
+          path: dist/
+          retention-days: 1
+
+  test-pytest:
+    name: Run tests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository for test files
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Download dist files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
+          path: dist/
+
+      - name: Install wheel with test extras
+        run: |
+          python -m pip install --upgrade pip
+          WHEEL_FILE=$(ls dist/*.whl)
+          pip install "${WHEEL_FILE}[test]"
+
+      - name: Test import
+        run: |
+          python -c "import multibind; print(f'Package {multibind.__version__} imported successfully')"
+
+      - name: Run tests
+        run: |
+          cd tests && pytest --verbose
+
+  deploy-testpypi:
+    name: Deploy to TestPyPI
+    runs-on: ubuntu-latest
+    needs: [build, test-pytest]
+    if: |
+      github.repository == 'BecksteinLab/multibind' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/multibind
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download dist files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  deploy-pypi:
+    name: Deploy to PyPI
+    runs-on: ubuntu-latest
+    needs: [build, test-pytest]
+    if: |
+      github.repository == 'BecksteinLab/multibind' &&
+      (github.event_name == 'release' && github.event.action == 'published')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/multibind
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download dist files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  test-deployed-testpypi:
+    name: Test deployed package (TestPyPI)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    needs: [build, deploy-testpypi]
+    if: |
+      github.repository == 'BecksteinLab/multibind' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Checkout repository for actions
+        uses: actions/checkout@v4
+
+      - name: Wait for version to be available on TestPyPI
+        uses: ./.github/actions/wait-for-pypi-version
+        with:
+          repository: testpypi
+          package: multibind
+          version: ${{ needs.build.outputs.version }}
+
+      - name: Install from TestPyPI
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "multibind[test]==${{ needs.build.outputs.version }}"
+
+      - name: Test import
+        run: |
+          python -c "import multibind; print(f'Package {multibind.__version__} imported successfully from TestPyPI')"
+
+      - name: Run tests
+        run: |
+          git clone --depth 1 https://github.com/${{ github.repository }}.git _src
+          cd _src/tests/
+          pytest -v
+
+  test-deployed-pypi:
+    name: Test deployed package (PyPI)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    needs: [build, deploy-pypi]
+    if: |
+      github.repository == 'BecksteinLab/multibind' &&
+      (github.event_name == 'release' && github.event.action == 'published')
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Checkout repository for actions
+        uses: actions/checkout@v4
+
+      - name: Wait for version to be available on PyPI
+        uses: ./.github/actions/wait-for-pypi-version
+        with:
+          repository: pypi
+          package: multibind
+          version: ${{ needs.build.outputs.version }}
+
+      - name: Install from PyPI
+        run: |
+          python -m pip install --upgrade pip
+          pip install "multibind[test]==${{ needs.build.outputs.version }}"
+
+      - name: Test import
+        run: |
+          python -c "import multibind; print(f'Package {multibind.__version__} imported successfully from PyPI')"
+
+      - name: Run tests
+        run: |
+          git clone --depth 1 https://github.com/${{ github.repository }}.git _src
+          cd _src/tests/
+          pytest -v

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,13 +24,13 @@ jobs:
       version: ${{ steps.extract-version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -60,7 +60,7 @@ jobs:
           echo "Extracted version: $VERSION"
 
       - name: Upload dist files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-files
           path: dist/
@@ -72,18 +72,18 @@ jobs:
     needs: build
     steps:
       - name: Checkout repository for test files
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
       - name: Download dist files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist-files
           path: dist/
@@ -116,7 +116,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download dist files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist-files
           path: dist/
@@ -140,7 +140,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download dist files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist-files
           path: dist/
@@ -161,12 +161,12 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
       - name: Checkout repository for actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Wait for version to be available on TestPyPI
         uses: ./.github/actions/wait-for-pypi-version
@@ -203,12 +203,12 @@ jobs:
       (github.event_name == 'release' && github.event.action == 'published')
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
       - name: Checkout repository for actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Wait for version to be available on PyPI
         uses: ./.github/actions/wait-for-pypi-version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install multibind with poetry
       run: |
-        poetry install
+        poetry install --extras dev
 
     - name: Test with pytest
       run: |

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 orbeckst
 
 Support Python 3.10 - 3.14.
+Package version is derived from Git tags via versioningit (setuptools build backend).
 
 
 2022-02-22    0.2.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,53 +1,77 @@
 # Installing multibind
 
+## Install from PyPI
+
+For most users, install the latest release with pip:
+
+```bash
+python -m pip install --upgrade pip
+pip install multibind
+```
+
 ## Requirements
 
 - **Python** 3.10, 3.11, 3.12, 3.13, or 3.14 (see `pyproject.toml` for the exact supported range).
-- **Dependencies** (installed automatically with the methods below): NumPy, pandas, SciPy, NetworkX, and xarray. NumPy 1.x is allowed on older Pythons; very new interpreters (for example 3.14) typically need a **NumPy 2.x** build that provides wheels for that version.
+- **Runtime dependencies** (pulled in automatically): NumPy, pandas, SciPy, NetworkX, and xarray. NumPy 1.x is allowed on older Pythons; very new interpreters (for example 3.14) typically need a **NumPy 2.x** build with wheels for that version.
 
-## Install with Poetry (recommended for development)
+## Conda or Mamba
 
-[Poetry](https://python-poetry.org/docs/#installation) manages the environment and resolves versions from `pyproject.toml`.
+Create an environment with a suitable Python version, activate it, then use **pip** to install **multibind** as above. Avoid mixing multiple installers for the same package in one environment unless you know how they interact.
 
-From the root of a clone of this repository:
+
+## For developers and contributors
+
+The sections below cover working from a **Git clone**: versioning, Poetry, editable installs, tests, and documentation.
+
+### Versioning and Git tags
+
+Release versions on PyPI are produced with [versioningit](https://github.com/jwodder/versioningit) at **build** time from Git. Release tags must look like **`vMAJOR.MINOR.PATCH`** (for example `v0.2.0`); the leading `v` is removed in the published version string (see `pyproject.toml`).
+
+Install from a **full** clone (`git clone`, not a tree without `.git`) when you build wheels or sdists locally so versioningit can read the repository.
+
+### Install with Poetry
+
+[Poetry](https://python-poetry.org/docs/#installation) resolves dependencies from `pyproject.toml` and is convenient for day-to-day development on a clone.
+
+From the repository root:
+
+```bash
+poetry install --extras dev
+```
+
+**Why `--extras dev`?** The **`dev`** optional dependency group adds tools you need on a clone: **pytest**, **pytest-cov**, **Sphinx**, **IPython**, **versioningit**, and similar. Without it you cannot run the test suite or build the HTML docs in the usual way.
+
+**Why is versioningit in `dev`?** The package version is **dynamic** (from Git tags via setuptools + versioningit when you run `pip install` / `python -m build`). Poetry’s **editable** install records a **`0.0.0`** placeholder in environment metadata. With **versioningit** installed, `multibind.__version__` can fall back to a real version derived from the repo (see `multibind/__init__.py`). Installs from PyPI always get the correct version from package metadata.
+
+Runtime-only dependencies (no tests or docs tooling):
 
 ```bash
 poetry install
 ```
 
-This installs **multibind** in editable mode plus **dev** tools (pytest, Sphinx, IPython, etc.).
-
-To install only runtime dependencies (no dev extras):
-
-```bash
-poetry install --without dev
-```
-
-Run the test suite (paths in the tests assume the working directory is `tests/`):
+Run the tests (paths assume the working directory is `tests/`):
 
 ```bash
 cd tests
 poetry run pytest -v
 ```
 
-## Install with pip
+### Install with pip from a clone
 
-### From a local checkout
-
-Create and activate a virtual environment, then from the repository root:
+With `.git` present so versioningit can run during the build:
 
 ```bash
 python -m pip install --upgrade pip
 pip install .
 ```
 
-Editable install while you change the code:
+Editable install while you change the code (includes dev tools for tests/docs):
 
 ```bash
-pip install -e .
+pip install -e ".[dev]"
 ```
 
-### From GitHub
+### Install from GitHub
 
 Replace the URL if you use a fork:
 
@@ -57,25 +81,13 @@ pip install "multibind @ git+https://github.com/BecksteinLab/multibind.git"
 
 For a specific branch or tag, use the corresponding revision in the URL (see [pip VCS support](https://pip.pypa.io/en/stable/topics/vcs-support/)).
 
-### From PyPI
+### Documentation
 
-If a release is published on PyPI:
+Online: [multibind.readthedocs.io](https://multibind.readthedocs.io/).
 
-```bash
-pip install multibind
-```
-
-## Conda or Mamba environments
-
-Create an environment with a suitable Python version, activate it, then use **pip** inside that environment as above (from a clone or from Git/PyPI). Avoid mixing Poetry and conda installs of the same package in one environment unless you know how they interact.
-
-## Documentation
-
-To build the HTML docs locally, install dev dependencies (e.g. `poetry install`), then:
+To build HTML locally, install dev dependencies (for example `poetry install --extras dev` or `pip install -e ".[dev]"`), then:
 
 ```bash
 cd docs
 sphinx-build -b html . _build/html
 ```
-
-Online documentation: [multibind.readthedocs.io](https://multibind.readthedocs.io/).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ From the repository root:
 poetry install --extras dev
 ```
 
-**Why `--extras dev`?** The **`dev`** optional dependency group adds tools you need on a clone: **pytest**, **pytest-cov**, **Sphinx**, **IPython**, **versioningit**, and similar. Without it you cannot run the test suite or build the HTML docs in the usual way.
+**Why `--extras dev`?** The **`dev`** optional dependency group adds tools you need on a clone: **pytest**, **pytest-cov**, **Sphinx**, **versioningit**, and similar. Without it you cannot run the test suite or build the HTML docs in the usual way. (Install **IPython** yourself if you want it for interactive work; it is not required by this package.)
 
 **Why is versioningit in `dev`?** The package version is **dynamic** (from Git tags via setuptools + versioningit when you run `pip install` / `python -m build`). Poetry’s **editable** install records a **`0.0.0`** placeholder in environment metadata. With **versioningit** installed, `multibind.__version__` can fall back to a real version derived from the repo (see `multibind/__init__.py`). Installs from PyPI always get the correct version from package metadata.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune tests

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ Additionally, multibind supports cycles whose free energies are dependent on mul
 
 ## Installation
 
-Requires **Python 3.10** through **3.14**. With [Poetry](https://python-poetry.org/):
+**multibind** is on [PyPI](https://pypi.org/project/multibind/). You need **Python 3.10** through **3.14**.
 
 ```bash
-poetry install
+pip install multibind
 ```
 
-For pip, conda, editable installs, tests, and building docs, see **[INSTALL.md](INSTALL.md)**.
+Using conda or mamba, create an environment with a suitable Python version, then run the same command inside it.
+
+To work from a Git clone (editable install), run tests, build docs, or use Poetry, see **[INSTALL.md](INSTALL.md)**.
 
 ## State definitions
 

--- a/multibind/__init__.py
+++ b/multibind/__init__.py
@@ -1,6 +1,21 @@
-from importlib.metadata import version
+from pathlib import Path
+
 from .multibind import Multibind
 
-__version__ = version("multibind")
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
-del version
+try:
+    from importlib.metadata import version as _package_version
+
+    __version__ = _package_version("multibind")
+except Exception:  # pragma: no cover
+    __version__ = "0.0.0"
+
+# Poetry editable installs can leave metadata at the placeholder; use versioningit from a dev env.
+if __version__ == "0.0.0":
+    try:
+        from versioningit import get_version
+
+        __version__ = get_version(_PROJECT_ROOT)
+    except Exception:  # pragma: no cover
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,61 @@
-[tool.poetry]
-name = "multibind"
-version = "0.2.0"
-description = "A package to find optimal state free energies from a thermodynamic graph."
-authors = ["Ian Kenney <ikenney@asu.edu>"]
-license = "MIT"
-
-[tool.poetry.dependencies]
-python = ">=3.10,<3.15"
-# Dependency floors: see PyPI requires_python / classifiers for 3.10–3.14 (pandas 2.3.3+ for 3.14; scipy ≥1.11.4 for 3.13+).
-numpy = ">=1.22.4,<3"
-pandas = ">=2.3.3,<3"
-scipy = ">=1.11.4,<2"
-networkx = ">=3.2,<4"
-xarray = ">=2024.1"
-
-[tool.poetry.group.dev.dependencies]
-pytest = "^8.0"
-ipython = "^8.18"
-pytest-cov = "^5.0"
-Sphinx = "^8.0"
-
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools>=61", "versioningit>=3.0,<4"]
+build-backend = "setuptools.build_meta"
+
+# Poetry requires a placeholder when `version` is dynamic (actual value comes from versioningit at build).
+[tool.poetry]
+version = "0.0.0"
+
+[project]
+name = "multibind"
+dynamic = ["version"]
+description = "A package to find optimal state free energies from a thermodynamic graph."
+readme = "README.md"
+requires-python = ">=3.10,<3.15"
+license = "MIT"
+authors = [{ name = "Ian Kenney", email = "ikenney@asu.edu" }]
+# Floors: PyPI classifiers / requires_python for CPython 3.10–3.14 (see prior audit).
+dependencies = [
+    "numpy>=1.22.4,<3",
+    "pandas>=2.3.3,<3",
+    "scipy>=1.11.4,<2",
+    "networkx>=3.2,<4",
+    "xarray>=2024.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0,<9",
+    "ipython>=8.18",
+    "pytest-cov>=5.0,<6",
+    "sphinx>=8.0,<10",
+    "versioningit>=3.0,<4",
+]
+test = [
+    "pytest>=8.0,<9",
+    "pytest-cov>=5.0,<6",
+]
+
+[project.urls]
+Homepage = "https://github.com/BecksteinLab/multibind"
+Documentation = "https://multibind.readthedocs.io/"
+
+[tool.setuptools]
+packages = ["multibind"]
+
+[tool.versioningit]
+# PEP 440 public versions only (no +local), so sdists/wheels are PyPI-safe off-tag.
+[tool.versioningit.format]
+distance = "{base_version}.dev{distance}"
+dirty = "{base_version}"
+distance-dirty = "{base_version}.dev{distance}"
+
+[tool.versioningit.tag2version]
+# Explicit: tags are vX.Y.Z; published metadata uses X.Y.Z (PEP 440).
+rmprefix = "v"
+
+[tool.versioningit.vcs]
+# git describe --match=v* so only annotated/lightweight release tags like v0.2.0 are used.
+match = ["v*"]
+# Shallow clones / no matching tags: synthetic tag v0.0.0 → version 0.0.0 after tag2version.
+default-tag = "v0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0,<9",
-    "ipython>=8.18",
     "pytest-cov>=5.0,<6",
     "sphinx>=8.0,<10",
     "versioningit>=3.0,<4",


### PR DESCRIPTION
- fix #25
- automate deployment on tag (to testpypi) and release (to pypi)
- test deployed versions (including waiting for the release to show up)
- use versioningit to dynamically set version from git tag (requires some workarounds for poetry)
- updated installation instructions to first point to pypi
- clean install (do not include tests directory)

Used cursor.